### PR TITLE
groundwork: for cheatsheets

### DIFF
--- a/_cheatsheets/linux.md
+++ b/_cheatsheets/linux.md
@@ -1,6 +1,5 @@
 ---
 permalink: linux
-layout: default
 ---
 
 # The Linux Cheatsheet

--- a/_cheatsheets/linux.md
+++ b/_cheatsheets/linux.md
@@ -1,0 +1,6 @@
+---
+permalink: linux
+layout: default
+---
+
+# The Linux Cheatsheet

--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,18 @@ theme: minima
 plugins:
   - jekyll-feed
 
+collections:
+  cheatsheets:
+    output: true
+
+defaults:
+  -
+    scope:
+      type: "cheatsheets"
+      path: ""
+    values:
+      layout: cheatsheet
+
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to

--- a/_layouts/cheatsheet.html
+++ b/_layouts/cheatsheet.html
@@ -1,0 +1,3 @@
+---
+layout: post
+---


### PR DESCRIPTION
### create collection `cheatsheets`
Jekyll posts require files be named in a particular format.
The format is neither useful nor convenient for our uses.
A collection circumvents the need to use the prescribed format
while maintaining logical grouping in the form of a directory.

### create empty layout `cheatsheet` inheriting `post`
Not sure, but separating layout might help compartmentalise crazy styling
without affecting rest of the site.

### dummy linux cheatsheet
Just to check the new dir of the collection into the repo